### PR TITLE
gifski-app: track non-App Store version from readme

### DIFF
--- a/Casks/custom/gifski-app.rb
+++ b/Casks/custom/gifski-app.rb
@@ -2,7 +2,7 @@ cask "gifski-app" do
   # "Updated once a year" at
   # https://github.com/sindresorhus/Gifski
 
-  version "3.0.0"
+  version "3.0.2"
   sha256 "11f47f7a27edd7d0867e97f718c7a6dd3579df73a4d9f741f558d546a3cd61c9"
 
   # Version at end of the url works around Homebrew's

--- a/Casks/custom/gifski-app.rb
+++ b/Casks/custom/gifski-app.rb
@@ -1,22 +1,22 @@
 cask "gifski-app" do
-  # "Updated once a year" at
-  # https://github.com/sindresorhus/Gifski
+  # The non-App Store build is published only as a Dropbox link in the
+  # readme, "updated once a year". GitHub releases track the App Store
+  # version, so livecheck must read the readme instead.
+  version "3.0.1,1777713407,sz7f7zr673ii0kbm32v53,j6y2ehotb5ngbjbceg8qs8m1t"
+  sha256 "39245d120ca4e39e086d808fbf3205411d5e5592d0f2829c0d8e77e0ae1fdf86"
 
-  version "3.0.2"
-  sha256 "11f47f7a27edd7d0867e97f718c7a6dd3579df73a4d9f741f558d546a3cd61c9"
-
-  # Version at end of the url works around Homebrew's
-  # insistence on skipping checksums on unversioned URLs.
-  url "https://www.dropbox.com/scl/fi/2i6entp1fj83zb16al3yf/Gifski-3.0.0-1777056640.zip?rlkey=ealuyayatxef5g61yl9240eyc&raw=1##{version}",
+  url "https://www.dropbox.com/scl/fi/#{version.csv.third}/Gifski-#{version.csv.first}-#{version.csv.second}.zip?rlkey=#{version.csv.fourth}&raw=1",
       verified: "dropbox.com/"
   name "Gifski"
   desc "GUI for Gifski video to gif conversion library"
   homepage "https://sindresorhus.com/gifski"
 
   livecheck do
-    url "https://github.com/sindresorhus/Gifski"
-    strategy :github_latest
-    regex(/^v?(\d+(?:\.\d+)+)$/)
+    url "https://raw.githubusercontent.com/sindresorhus/Gifski/refs/heads/main/readme.md"
+    regex(%r{dropbox\.com/scl/fi/([^/]+)/Gifski-(\d+(?:\.\d+)+)-(\d+)\.zip\?rlkey=(\w+)}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |file_id, ver, build, rlkey| "#{ver},#{build},#{file_id},#{rlkey}" }
+    end
   end
 
   depends_on macos: :tahoe


### PR DESCRIPTION
The auto-bump to 3.0.2 followed GitHub release tags, which track the App Store version — it changed the cask version without changing the URL or hash. The actual non-App Store build is only published as a Dropbox link in the [readme](https://github.com/sindresorhus/Gifski#non-app-store-version), currently at 3.0.1.

- Set version to the real non-App Store release (3.0.1) with the Dropbox URL's unpredictable parts (build timestamp, file id, rlkey) encoded as CSV so the URL interpolates from the version
- Point livecheck at the raw readme with a `page_match` regex that extracts all four components
- Update sha256 to match the 3.0.1 artifact

Verified with `brew livecheck` (matches and reports up to date), `brew style`, and `brew fetch` (checksum passes).